### PR TITLE
Install 'Geocoder' gem for geolocation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'figaro'
 gem 'bcrypt', '~>3.1.10'
+gem 'geocoder'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       i18n (~> 0.5)
     figaro (1.1.1)
       thor (~> 0.14)
+    geocoder (1.2.9)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -203,6 +204,7 @@ DEPENDENCIES
   fabrication (~> 2.14.1)
   faker
   figaro
+  geocoder
   jbuilder (~> 2.0)
   jquery-rails
   pg

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -2,4 +2,7 @@ class Location < ActiveRecord::Base
   belongs_to :user
   validates_presence_of :user
   validates_presence_of :address, :city, :state, :zip_code
+
+  geocoded_by :address
+  after_validation :geocode
 end

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe LocationsController, :type => :controller do
         expect(flash[:success]).to eq("Location was successfully created.")
       end
     end
+
+    it "sets the latitude and longitude of the location" do
+        post :create, location: Fabricate.attributes_for(:location)
+
+        expect(Location.last.latitude).to eq(47.6204)
+        expect(Location.last.longitude).to eq(122.3491)
+      end
+
     
     context "an unsuccessful create" do
       before(:each) do
@@ -40,6 +48,7 @@ RSpec.describe LocationsController, :type => :controller do
       end
       
       it "does not save the new user object with invalid inputs" do
+        
         expect(Location.count).to eq(0)
       end
 
@@ -58,13 +67,16 @@ RSpec.describe LocationsController, :type => :controller do
 
     it "returns a successful http request status code" do
       get :show, id: location.id
+
       expect(response).to have_http_status(:success)
     end
   end
 
   describe "GET #edit" do
     let!(:location) { Fabricate(:location) }
+
     it "sends a successful edit request" do
+
       get :edit, id: location
 
       expect(response).to have_http_status(:success)
@@ -76,13 +88,16 @@ RSpec.describe LocationsController, :type => :controller do
     context "a successful update" do
 
       before(:each) do
-        put :update, id: location.id, :location => { address: "101 Main St." }
+        put :update, id: location.id, :location => { address: "101 Main St.", latitude: 48.6504, longitude: 125.1234 }
+        location.reload
       end
 
       it "updates the location object" do
 
         expect(Location.last.address).to eq("101 Main St.")
         expect(Location.last.address).not_to eq("101 Old Main St.")
+        expect(Location.last.latitude).to eq(48.6504)
+        expect(Location.last.longitude).to eq(125.1234)
       end
 
       it "sets a 'success' flash message" do

--- a/spec/fabricators/location_fabricator.rb
+++ b/spec/fabricators/location_fabricator.rb
@@ -2,6 +2,8 @@ Fabricator(:location) do
   user { Fabricate(:user) }
   id 100
   address { Faker::Address.street_name }
+  latitude 47.6204
+  longitude 122.3491
   city { Faker::Address.city }
   state { Faker::Address.state_abbr }
   zip_code { Faker::Address.zip_code }

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -10,3 +10,4 @@ RSpec.describe Location, type: :model do
   it { should validate_presence_of(:zip_code) }
 
 end
+

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,8 +57,9 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
+  # Include Spec Feature Helpers (/spec/support/features/)
   config.include Features, type: :feature
-  
+
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,8 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+
+  
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
This commit includes:
- The 'geocoder' gem, which finds the latitude and longitude of locations and commits them to the database.
- 'LocationsController' tests to ensure that the latitude data is correctly created and updated.
- An updated 'Location.rb' model to call Geocoder.
